### PR TITLE
Properly warn if a package lacks [lib] target

### DIFF
--- a/src/bin/cargo_semver.rs
+++ b/src/bin/cargo_semver.rs
@@ -119,6 +119,13 @@ fn run(config: &cargo::Config, matches: &getopts::Matches) -> Result<()> {
     };
     let name = current.package.name().to_owned();
 
+    if !current.package.targets().iter().any(|t| t.is_lib()) {
+        return Err(anyhow::anyhow!(
+            "package `{}` lacks required [lib] target",
+            &name
+        ));
+    }
+
     // TODO: JSON output here
     if matches.opt_present("show-public") {
         let (current_rlib, current_deps_output) =


### PR DESCRIPTION
Otherwise it errors out with a "lost build artifact", which may be hard to decipher.

Discovered this when running `cargo semver` on a package that is only a binary - while it seems obvious (there's no public crate API in the first place), the original error message left me wondering if there is something wrong with the build artifact (e.g. internal logic error or multiple `cargo` instances running for the same target). Hopefully, this will make it more clear that it only works on a package with `[lib]` target.

cc @ibabushkin 
r? @Manishearth 