### PR TITLE
Speed compilation by using .rmeta over .rlib files

### DIFF
--- a/src/bin/cargo-semver.rs
+++ b/src/bin/cargo-semver.rs
@@ -473,8 +473,10 @@ impl<'a> WorkInfo<'a> {
         current: bool,
         matches: &getopts::Matches,
     ) -> Result<(PathBuf, PathBuf)> {
-        let mut opts =
-            cargo::ops::CompileOptions::new(config, cargo::core::compiler::CompileMode::Build)?;
+        // We don't need codegen-ready artifacts (which .rlib files are) so
+        // settle for .rmeta files, which result from `cargo check` mode
+        let mode = cargo::core::compiler::CompileMode::Check { test: false };
+        let mut opts = cargo::ops::CompileOptions::new(config, mode)?;
         // we need the build plan to find our build artifacts
         opts.build_config.build_plan = true;
 


### PR DESCRIPTION
Fixes #125 

### Before
```
Benchmark #1: cargo semver -S libc:0.2.28 -C libc:0.2.31
  Time (mean ± σ):     810.7 ms ±  16.1 ms    [User: 639.3 ms, System: 97.9 ms]
  Range (min … max):   787.2 ms … 841.7 ms    10 runs

Benchmark #2: cargo semver -S log:0.3.4 -C log:0.4.0
  Time (mean ± σ):     897.0 ms ±  13.4 ms    [User: 901.3 ms, System: 160.0 ms]
  Range (min … max):   869.6 ms … 913.9 ms    10 runs

Benchmark #3: cargo semver -S rmpv:0.4.0 -C rmpv:0.4.1
  Time (mean ± σ):      3.373 s ±  0.032 s    [User: 4.984 s, System: 0.651 s]
  Range (min … max):    3.308 s …  3.414 s    10 runs

Benchmark #4: cargo semver -S serde_json:1.0.0 -C serde_json:1.0.40
  Time (mean ± σ):      9.437 s ±  0.066 s    [User: 12.480 s, System: 0.649 s]
  Range (min … max):    9.329 s …  9.519 s    10 runs
```

### After
```
Benchmark #1: cargo semver -S libc:0.2.28 -C libc:0.2.31
  Time (mean ± σ):     256.0 ms ±   6.6 ms    [User: 90.0 ms, System: 28.1 ms]
  Range (min … max):   248.0 ms … 270.7 ms    11 runs

Benchmark #2: cargo semver -S log:0.3.4 -C log:0.4.0
  Time (mean ± σ):     221.3 ms ±  12.8 ms    [User: 57.8 ms, System: 23.5 ms]
  Range (min … max):   207.8 ms … 250.2 ms    14 runs

Benchmark #3: cargo semver -S rmpv:0.4.0 -C rmpv:0.4.1
  Time (mean ± σ):      3.027 s ±  0.037 s    [User: 3.143 s, System: 0.456 s]
  Range (min … max):    2.980 s …  3.093 s    10 runs

Benchmark #4: cargo semver -S serde_json:1.0.0 -C serde_json:1.0.40
  Time (mean ± σ):      2.038 s ±  0.464 s    [User: 1.829 s, System: 0.249 s]
  Range (min … max):    1.857 s …  3.356 s    10 run
```

This aims to confirm speed benefits in semverver itself rather than to serve as a benchmark for `cargo build` vs `cargo check`.

r? @eddyb