### PR TITLE
Trigger CI for bors-managed `auto` branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   push:
     branches:
       - master
+      # Managed by bors
+      - auto
 
 jobs:
   build_and_test:


### PR DESCRIPTION
Otherwise the bot is not informed whether its merge successfully passed the CI test suite.