### PR TITLE
Bump Cargo to 0.48

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license-file = "LICENSE"
 edition = "2018"
 
 [dependencies]
-cargo = "0.45"
+cargo = "0.48"
 crates-io = "0.32"
 curl = "0.4.21"
 env_logger = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ curl = "0.4.21"
 env_logger = "0.7"
 anyhow = "1.0.27"
 log = "0.4"
-rand = "0.7"
 semver = "0.9"
 serde = { version = "1.0.84", features = ["derive"] }
 serde_json = "1.0.34"
 
 [dev-dependencies]
 quickcheck = "0.9"
+rand = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license-file = "LICENSE"
 edition = "2018"
 
 [dependencies]
-cargo = "0.44"
+cargo = "0.45"
 crates-io = "0.32"
 curl = "0.4.21"
 env_logger = "0.7"


### PR DESCRIPTION
The main change is in https://github.com/rust-lang/rust-semverver/commit/89384957cc45432e63bb026dde2c2a17c341df58, which works around https://github.com/rust-lang/cargo/pull/8236 that introduced different mechanism to output stdio/shell-based data. 

Everything now goes through cargo `Shell` type so `std::io::set_print` trick stopped working - instead, we create our custom shell and fetch the build plan through it.

r? @Manishearth or @ibabushkin 