### PR TITLE
Do not specify `nightly` in favor of `rust-toolchain`

### DIFF
--- a/ci/setup-toolchain.sh
+++ b/ci/setup-toolchain.sh
@@ -10,10 +10,10 @@ CARGO_HOME=${CARGO_HOME:-$HOME/.cargo}
 
 # Check if RTIM is not installed or installed in other locations not in ~/.cargo/bin
 if [[ "$INSTALLED" == false || "$RTIM_PATH" == $CARGO_HOME/bin/rustup-toolchain-install-master ]]; then
-    cargo +nightly install rustup-toolchain-install-master
+    cargo install rustup-toolchain-install-master
 else
     VERSION=$(rustup-toolchain-install-master -V | grep -o "[0-9.]*")
-    REMOTE=$(cargo +nightly search rustup-toolchain-install-master | grep -o "[0-9.]*")
+    REMOTE=$(cargo search rustup-toolchain-install-master | grep -o "[0-9.]*")
     echo "info: skipping updating rustup-toolchain-install-master at $RTIM_PATH"
     echo "      current version : $VERSION"
     echo "      remote version  : $REMOTE"


### PR DESCRIPTION
The scheduled CI fails because we don't have `nightly` toolchain, but `nightly-20XX-XX-XX` on CI (https://github.com/rust-lang/rust-semverver/actions/runs/380029548). Since we specify the toolchain via `rust-toolchain`, I think `+nightly` isn't needed here.