### PR TITLE
Fix the sheduled job to check with the latest master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Setup latest nightly toolchain
-        run: bash ci/setup-toolchain.sh
+      - name: Run tests (scheduled)
         if: github.event_name == 'schedule'
+        env:
+          SCHEDULED: 1
+        run: sh ci/run.sh ${{ matrix.os }}
       - name: Run tests
+        if: github.event_name != 'schedule'
         run: sh ci/run.sh ${{ matrix.os }}
 
   # https://forge.rust-lang.org/infra/docs/bors.html#adding-a-new-repository-to-bors


### PR DESCRIPTION
The current scheduled job doesn't fail due to misconfiguration because it doesn't override the toolchain actually (e.g. https://github.com/rust-lang/rust-semverver/actions/runs/474822307).
This fixes that issue and it will fail _correctly_.