### PR TITLE
Don't set override in CI script's dir

### DIFF
--- a/ci/setup-toolchain.sh
+++ b/ci/setup-toolchain.sh
@@ -3,8 +3,6 @@
 
 set -e
 
-cd "$(dirname "$0")"
-
 RTIM_PATH=$(command -v rustup-toolchain-install-master) || INSTALLED=false
 CARGO_HOME=${CARGO_HOME:-$HOME/.cargo}
 


### PR DESCRIPTION
Closes #147 

Otherwise the `rustup override` is effective only in the `ci/` directory, which is not what we want.
Tested locally and seems to be working as intended.

r? @JohnTitor 
