### PR TITLE
Use new format `rust-toolchain`

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -11,8 +11,6 @@ if [ "${OS}" = "windows" ]; then
     rustup set default-host x86_64-pc-windows-msvc
 fi
 
-rustup component add rustc-dev llvm-tools-preview
-
 cargo build
 cargo test --verbose -- --nocapture
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,3 @@
-nightly-2020-11-19
+[toolchain]
+channel = "nightly-2020-11-19"
+components = ["llvm-tools-preview", "rustc-dev"]


### PR DESCRIPTION
So that we don't have to run `rustup component add ...` anymore.