### PR TITLE
Update `cargo` and `crates-io` deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,9 +79,9 @@ checksum = "81a18687293a1546b67c246452202bbbf143d239cb43494cc163da14979082da"
 
 [[package]]
 name = "cargo"
-version = "0.51.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d89cbdcbeada632f64aa9f692e265852b0eb6ccdf3b1814716cc62101eeb6"
+checksum = "668794d3757557250a8b7bf7d0920ca60910d9635e76d008caed037ec25c39b3"
 dependencies = [
  "anyhow",
  "atty",
@@ -218,15 +218,14 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "crates-io"
-version = "0.31.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f977948a46e9edf93eb3dc2d7a8dd4ce3105d36de63300befed37cdf051d4a"
+checksum = "217138863f33507d7a8edef10fc673c4911679ef7aeb9ff53ee7bb82dc7bf590"
 dependencies = [
  "anyhow",
  "curl",
  "percent-encoding",
  "serde",
- "serde_derive",
  "serde_json",
  "url",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ license-file = "LICENSE"
 edition = "2018"
 
 [dependencies]
-cargo = "0.51"
-crates-io = "0.31" # Keep in sync with version pulled by Cargo
+cargo = "0.52"
+crates-io = "0.33" # Keep in sync with version pulled by Cargo
 curl = "0.4.35"
 env_logger = "0.8"
 anyhow = "1.0.40"


### PR DESCRIPTION
log:
```
Updating cargo v0.51.0 -> v0.52.0
Updating crates-io v0.31.1 -> v0.33.0
```

Closes #180