### PR TITLE
Update to nightly-2021-05-21

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ repository and compiled from source or installed from
 of the nightly toolchain is supported at any given time.
 
 <!-- NOTE: Keep in sync with nightly date on rust-toolchain. -->
-It's recommended to use `nightly-2020-12-20` toolchain.
-You can install it by using `rustup install nightly-2020-12-20` if you already have rustup.
+It's recommended to use `nightly-2021-05-21` toolchain.
+You can install it by using `rustup install nightly-2021-05-21` if you already have rustup.
 Then you can do:
 
 ```sh
-$ rustup component add rustc-dev llvm-tools-preview --toolchain nightly-2020-12-20
-$ cargo +nightly-2020-12-20 install --git https://github.com/rust-lang/rust-semverver
+$ rustup component add rustc-dev llvm-tools-preview --toolchain nightly-2021-05-21
+$ cargo +nightly-2021-05-21 install --git https://github.com/rust-lang/rust-semverver
 ```
 
 You'd also need `cmake` for some dependencies, and a few common libraries (if you hit

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 # NOTE: Keep in sync with nightly date on README
 [toolchain]
-channel = "nightly-2020-12-20"
+channel = "nightly-2021-05-21"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/src/changes.rs
+++ b/src/changes.rs
@@ -88,10 +88,11 @@ impl<'a> Serialize for RSpan<'a> {
 
         assert!(lo.file.name == hi.file.name);
         let file_name = if let FileName::Real(ref name) = lo.file.name {
-            format!("{}", name.local_path().display())
+            name.local_path().map(|p| format!("{}", p.display()))
         } else {
-            "no file name".to_owned()
-        };
+            None
+        }
+        .unwrap_or_else(|| "no file name".to_owned());
 
         let mut state = serializer.serialize_struct("Span", 5)?;
         state.serialize_field("file", &file_name)?;

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -181,7 +181,7 @@ impl IdMapping {
         match param.kind {
             GenericParamDefKind::Lifetime => unreachable!(),
             GenericParamDefKind::Type { .. } => (),
-            GenericParamDefKind::Const => unreachable!(),
+            GenericParamDefKind::Const { .. } => unreachable!(),
         };
 
         self.type_params.insert(param.def_id, param.clone());
@@ -237,10 +237,8 @@ impl IdMapping {
                 Some(new.1.def_id())
             } else if let Some(new) = self.trait_item_mapping.get(&old) {
                 Some(new.1.def_id())
-            } else if let Some(new_def_id) = self.internal_mapping.get(&old) {
-                Some(*new_def_id)
             } else {
-                None
+                self.internal_mapping.get(&old).copied()
             }
         } else {
             Some(old)

--- a/src/mismatch.rs
+++ b/src/mismatch.rs
@@ -305,9 +305,9 @@ impl<'a, 'tcx> TypeRelation<'tcx> for MismatchRelation<'a, 'tcx> {
 
     fn binders<T: Relate<'tcx>>(
         &mut self,
-        a: ty::Binder<T>,
-        b: ty::Binder<T>,
-    ) -> RelateResult<'tcx, ty::Binder<T>> {
+        a: ty::Binder<'tcx, T>,
+        b: ty::Binder<'tcx, T>,
+    ) -> RelateResult<'tcx, ty::Binder<'tcx, T>> {
         Ok(a.rebind(self.relate(a.skip_binder(), b.skip_binder())?))
     }
 }

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -568,7 +568,7 @@ fn diff_traits<'tcx>(
 ) {
     use rustc_hir::Unsafety::Unsafe;
     use rustc_middle::ty::subst::GenericArgKind::Type;
-    use rustc_middle::ty::{ParamTy, PredicateAtom};
+    use rustc_middle::ty::{ParamTy, PredicateKind};
 
     debug!(
         "diff_traits: old: {:?}, new: {:?}, output: {:?}",
@@ -590,7 +590,7 @@ fn diff_traits<'tcx>(
     let old_param_env = tcx.param_env(old);
 
     for bound in old_param_env.caller_bounds() {
-        if let PredicateAtom::Trait(pred, _) = bound.skip_binders() {
+        if let PredicateKind::Trait(pred, _) = bound.kind().skip_binder() {
             let trait_ref = pred.trait_ref;
 
             debug!("trait_ref substs (old): {:?}", trait_ref.substs);

--- a/src/typeck.rs
+++ b/src/typeck.rs
@@ -18,8 +18,7 @@ use rustc_middle::{
         error::TypeError,
         fold::TypeFoldable,
         subst::{GenericArg, InternalSubsts, SubstsRef},
-        GenericParamDefKind, ParamEnv, Predicate, PredicateAtom, PredicateKind, TraitRef, Ty,
-        TyCtxt,
+        GenericParamDefKind, ParamEnv, Predicate, PredicateKind, TraitRef, Ty, TyCtxt,
     },
 };
 use rustc_trait_selection::traits::FulfillmentContext;
@@ -74,15 +73,15 @@ impl<'a, 'tcx> BoundContext<'a, 'tcx> {
     /// Register the trait bound represented by a `TraitRef`.
     pub fn register_trait_ref(&mut self, checked_trait_ref: TraitRef<'tcx>) {
         use rustc_hir::Constness;
-        use rustc_middle::ty::{Binder, TraitPredicate};
+        use rustc_middle::ty::{ToPredicate, TraitPredicate};
 
-        let predicate = Binder::bind(PredicateAtom::Trait(
+        let predicate = PredicateKind::Trait(
             TraitPredicate {
                 trait_ref: checked_trait_ref,
             },
             Constness::NotConst,
-        ))
-        .potentially_quantified(self.infcx.tcx, PredicateKind::ForAll);
+        )
+        .to_predicate(self.infcx.tcx);
         let obligation = Obligation::new(ObligationCause::dummy(), self.given_param_env, predicate);
         self.fulfill_cx
             .register_predicate_obligation(self.infcx, obligation);
@@ -205,7 +204,7 @@ impl<'a, 'tcx> TypeComparisonContext<'a, 'tcx> {
                     self.infcx.tcx.mk_param_from_def(def)
                 }
             }
-            GenericParamDefKind::Const => unreachable!(),
+            GenericParamDefKind::Const { .. } => unreachable!(),
         })
     }
 

--- a/tests/cases/func/new.rs
+++ b/tests/cases/func/new.rs
@@ -1,4 +1,3 @@
-#![feature(const_fn)]
 pub fn abc() {}
 
 pub fn bcd(_: u8) {}

--- a/tests/cases/func/old.rs
+++ b/tests/cases/func/old.rs
@@ -1,4 +1,3 @@
-#![feature(const_fn)]
 pub fn abc() {}
 
 pub fn bcd() {}

--- a/tests/cases/func/stdout
+++ b/tests/cases/func/stdout
@@ -1,64 +1,64 @@
 version bump: 1.0.0 -> (breaking) -> 2.0.0
 error: breaking changes in `bcd`
- --> func/new.rs:4:1
+ --> func/new.rs:3:1
   |
-4 | pub fn bcd(_: u8) {}
+3 | pub fn bcd(_: u8) {}
   | ^^^^^^^^^^^^^^^^^
   |
   = warning: type error: incorrect number of function parameters (breaking)
 
 error: breaking changes in `cde`
- --> func/new.rs:6:1
+ --> func/new.rs:5:1
   |
-6 | pub fn cde() -> u16 {
+5 | pub fn cde() -> u16 {
   | ^^^^^^^^^^^^^^^^^^^
   |
   = warning: type error: expected `()`, found `u16` (breaking)
 
 error: breaking changes in `def`
-  --> func/new.rs:10:1
-   |
-10 | pub fn def() {}
-   | ^^^^^^^^^^^^
-   |
-   = warning: type error: incorrect number of function parameters (breaking)
+ --> func/new.rs:9:1
+  |
+9 | pub fn def() {}
+  | ^^^^^^^^^^^^
+  |
+  = warning: type error: incorrect number of function parameters (breaking)
 
 warning: non-breaking changes in `efg`
-  --> func/new.rs:12:1
+  --> func/new.rs:11:1
    |
-12 | pub fn efg<A>(a: A, _: A) -> A {
+11 | pub fn efg<A>(a: A, _: A) -> A {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: defaulted type parameter added (non-breaking)
 
 error: breaking changes in `fgh`
-  --> func/new.rs:16:1
+  --> func/new.rs:15:1
    |
-16 | pub fn fgh(a: u8, _: u16) -> u8 {
+15 | pub fn fgh(a: u8, _: u16) -> u8 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: type error: expected `u8`, found `u16` (breaking)
 
 error: breaking changes in `ghi`
-  --> func/new.rs:20:1
+  --> func/new.rs:19:1
    |
-20 | pub fn ghi(a: u8, _: u8) -> u16 {
+19 | pub fn ghi(a: u8, _: u8) -> u16 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: type error: expected `u8`, found `u16` (breaking)
 
 warning: non-breaking changes in `hij`
-  --> func/new.rs:24:1
+  --> func/new.rs:23:1
    |
-24 | pub const fn hij() -> u8 {
+23 | pub const fn hij() -> u8 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: fn item made const (non-breaking)
 
 error: breaking changes in `ijk`
-  --> func/new.rs:28:1
+  --> func/new.rs:27:1
    |
-28 | pub fn ijk() -> u8 {
+27 | pub fn ijk() -> u8 {
    | ^^^^^^^^^^^^^^^^^^
    |
    = warning: fn item made non-const (breaking)

--- a/tests/cases/inherent_impls/stdout
+++ b/tests/cases/inherent_impls/stdout
@@ -2,30 +2,24 @@ version bump: 1.0.0 -> (breaking) -> 2.0.0
 error: breaking changes in `ghi`
   --> inherent_impls/old.rs:14:5
    |
-14 | /     pub fn ghi<A>(&self, a: A) -> A {
-15 | |         a
-16 | |     }
-   | |_____^
+14 |     pub fn ghi<A>(&self, a: A) -> A {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: type error: expected type parameter `A`, found `u8` (breaking)
 
 error: breaking changes in `def`
   --> inherent_impls/old.rs:26:5
    |
-26 | /     pub fn def(&self) -> u8 {
-27 | |         0
-28 | |     }
-   | |_____^
+26 |     pub fn def(&self) -> u8 {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: removed item in inherent impl (breaking)
 
 error: breaking changes in `def`
   --> inherent_impls/old.rs:33:5
    |
-33 | /     pub fn def(&self) -> u8 {
-34 | |         0
-35 | |     }
-   | |_____^
+33 |     pub fn def(&self) -> u8 {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: type error: expected `u8`, found `u16` (breaking)
 
@@ -33,7 +27,7 @@ error: breaking changes in `ghi`
   --> inherent_impls/old.rs:37:5
    |
 37 |     pub fn ghi() { }
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^
    |
    = warning: removed item in inherent impl (breaking)
 
@@ -41,17 +35,15 @@ warning: technically breaking changes in `abc`
   --> inherent_impls/new.rs:30:5
    |
 30 |     pub fn abc() { }
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^
    |
    = note: added item in inherent impl (technically breaking)
 
 warning: technically breaking changes in `def`
   --> inherent_impls/new.rs:37:5
    |
-37 | /     pub fn def(&self) -> u8 {
-38 | |         0
-39 | |     }
-   | |_____^
+37 |     pub fn def(&self) -> u8 {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: added item in inherent impl (technically breaking)
 

--- a/tests/cases/pathologic_paths/stdout
+++ b/tests/cases/pathologic_paths/stdout
@@ -12,7 +12,7 @@ warning: path changes to `a`
    | |_______________________^
    |
    = note: added definition (technically breaking)
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `blow` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: path changes to `b`
   --> pathologic_paths/new.rs:10:1
@@ -27,6 +27,6 @@ warning: path changes to `b`
    | |_______________________^
    |
    = note: added definition (technically breaking)
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `blow` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: 2 warnings emitted

--- a/tests/cases/traits/stdout
+++ b/tests/cases/traits/stdout
@@ -19,10 +19,8 @@ warning: removed item from trait (breaking)
 warning: removed defaulted item from trait (breaking)
   --> traits/old.rs:8:5
    |
-8  | /     fn test5() -> u8 {
-9  | |         0
-10 | |     }
-   | |_____^
+8  |     fn test5() -> u8 {
+   |     ^^^^^^^^^^^^^^^^
 warning: added item to trait (breaking)
   --> traits/new.rs:4:5
    |
@@ -31,10 +29,8 @@ warning: added item to trait (breaking)
 note: added defaulted item to trait (technically breaking)
   --> traits/new.rs:8:5
    |
-8  | /     fn test6() -> u8 {
-9  | |         0
-10 | |     }
-   | |_____^
+8  |     fn test6() -> u8 {
+   |     ^^^^^^^^^^^^^^^^
 
 error: breaking changes in `test7`
   --> traits/new.rs:11:5

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -80,10 +80,12 @@ mod features {
         }
 
         let expected_output = read_to_string(&expected_path)
-            .expect(&format!(
-                "could not read expected output from file {}",
-                expected_path.display()
-            ))
+            .unwrap_or_else(|_| {
+                panic!(
+                    "could not read expected output from file {}",
+                    expected_path.display()
+                )
+            })
             .lines()
             .map(|l| l.trim_end())
             .map(|l| l.to_string() + "\n")

--- a/tests/full.rs
+++ b/tests/full.rs
@@ -68,10 +68,12 @@ mod full {
         };
 
         let expected_output = read_to_string(&expected_path)
-            .expect(&format!(
-                "could not read expected output from file {}",
-                expected_path.display()
-            ))
+            .unwrap_or_else(|_| {
+                panic!(
+                    "could not read expected output from file {}",
+                    expected_path.display()
+                )
+            })
             .lines()
             .map(|l| l.trim_end())
             .map(|l| l.to_string() + "\n")

--- a/tests/full_cases/log-0.3.4-0.3.8.linux
+++ b/tests/full_cases/log-0.3.4-0.3.8.linux
@@ -6,7 +6,7 @@ warning: technically breaking changes in `<new::LogLevel as std::hash::Hash>`
     |                           ^^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogLevelFilter as std::hash::Hash>`
    --> log-0.3.8/src/lib.rs:410:27
@@ -15,7 +15,7 @@ warning: technically breaking changes in `<new::LogLevelFilter as std::hash::Has
     |                           ^^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogRecord<'a> as std::fmt::Debug>`
    --> log-0.3.8/src/lib.rs:517:10
@@ -24,7 +24,7 @@ warning: technically breaking changes in `<new::LogRecord<'a> as std::fmt::Debug
     |          ^^^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogMetadata<'a> as std::cmp::Eq>`
    --> log-0.3.8/src/lib.rs:552:10
@@ -33,7 +33,7 @@ warning: technically breaking changes in `<new::LogMetadata<'a> as std::cmp::Eq>
     |          ^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogMetadata<'a> as std::cmp::PartialEq>`
    --> log-0.3.8/src/lib.rs:552:14
@@ -42,7 +42,7 @@ warning: technically breaking changes in `<new::LogMetadata<'a> as std::cmp::Par
     |              ^^^^^^^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogMetadata<'a> as std::cmp::Ord>`
    --> log-0.3.8/src/lib.rs:552:25
@@ -51,7 +51,7 @@ warning: technically breaking changes in `<new::LogMetadata<'a> as std::cmp::Ord
     |                         ^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogMetadata<'a> as std::cmp::PartialOrd>`
    --> log-0.3.8/src/lib.rs:552:30
@@ -60,7 +60,7 @@ warning: technically breaking changes in `<new::LogMetadata<'a> as std::cmp::Par
     |                              ^^^^^^^^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogMetadata<'a> as std::hash::Hash>`
    --> log-0.3.8/src/lib.rs:552:42
@@ -69,7 +69,7 @@ warning: technically breaking changes in `<new::LogMetadata<'a> as std::hash::Ha
     |                                          ^^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogMetadata<'a> as std::fmt::Debug>`
    --> log-0.3.8/src/lib.rs:552:48
@@ -78,7 +78,7 @@ warning: technically breaking changes in `<new::LogMetadata<'a> as std::fmt::Deb
     |                                                ^^^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogLocation as std::cmp::Eq>`
    --> log-0.3.8/src/lib.rs:604:30
@@ -87,7 +87,7 @@ warning: technically breaking changes in `<new::LogLocation as std::cmp::Eq>`
     |                              ^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogLocation as std::cmp::PartialEq>`
    --> log-0.3.8/src/lib.rs:604:34
@@ -96,7 +96,7 @@ warning: technically breaking changes in `<new::LogLocation as std::cmp::Partial
     |                                  ^^^^^^^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogLocation as std::cmp::Ord>`
    --> log-0.3.8/src/lib.rs:604:45
@@ -105,7 +105,7 @@ warning: technically breaking changes in `<new::LogLocation as std::cmp::Ord>`
     |                                             ^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogLocation as std::cmp::PartialOrd>`
    --> log-0.3.8/src/lib.rs:604:50
@@ -114,7 +114,7 @@ warning: technically breaking changes in `<new::LogLocation as std::cmp::Partial
     |                                                  ^^^^^^^^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogLocation as std::hash::Hash>`
    --> log-0.3.8/src/lib.rs:604:62
@@ -123,7 +123,7 @@ warning: technically breaking changes in `<new::LogLocation as std::hash::Hash>`
     |                                                              ^^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: path changes to `set_logger_raw`
    --> log-0.3.8/src/lib.rs:713:1

--- a/tests/full_cases/log-0.3.4-0.3.8.osx
+++ b/tests/full_cases/log-0.3.4-0.3.8.osx
@@ -6,7 +6,7 @@ warning: technically breaking changes in `<new::LogLevel as std::hash::Hash>`
     |                           ^^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogLevelFilter as std::hash::Hash>`
    --> log-0.3.8/src/lib.rs:410:27
@@ -15,7 +15,7 @@ warning: technically breaking changes in `<new::LogLevelFilter as std::hash::Has
     |                           ^^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogRecord<'a> as std::fmt::Debug>`
    --> log-0.3.8/src/lib.rs:517:10
@@ -24,7 +24,7 @@ warning: technically breaking changes in `<new::LogRecord<'a> as std::fmt::Debug
     |          ^^^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogMetadata<'a> as std::cmp::Eq>`
    --> log-0.3.8/src/lib.rs:552:10
@@ -33,7 +33,7 @@ warning: technically breaking changes in `<new::LogMetadata<'a> as std::cmp::Eq>
     |          ^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogMetadata<'a> as std::cmp::PartialEq>`
    --> log-0.3.8/src/lib.rs:552:14
@@ -42,7 +42,7 @@ warning: technically breaking changes in `<new::LogMetadata<'a> as std::cmp::Par
     |              ^^^^^^^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogMetadata<'a> as std::cmp::Ord>`
    --> log-0.3.8/src/lib.rs:552:25
@@ -51,7 +51,7 @@ warning: technically breaking changes in `<new::LogMetadata<'a> as std::cmp::Ord
     |                         ^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogMetadata<'a> as std::cmp::PartialOrd>`
    --> log-0.3.8/src/lib.rs:552:30
@@ -60,7 +60,7 @@ warning: technically breaking changes in `<new::LogMetadata<'a> as std::cmp::Par
     |                              ^^^^^^^^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogMetadata<'a> as std::hash::Hash>`
    --> log-0.3.8/src/lib.rs:552:42
@@ -69,7 +69,7 @@ warning: technically breaking changes in `<new::LogMetadata<'a> as std::hash::Ha
     |                                          ^^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogMetadata<'a> as std::fmt::Debug>`
    --> log-0.3.8/src/lib.rs:552:48
@@ -78,7 +78,7 @@ warning: technically breaking changes in `<new::LogMetadata<'a> as std::fmt::Deb
     |                                                ^^^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogLocation as std::cmp::Eq>`
    --> log-0.3.8/src/lib.rs:604:30
@@ -87,7 +87,7 @@ warning: technically breaking changes in `<new::LogLocation as std::cmp::Eq>`
     |                              ^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogLocation as std::cmp::PartialEq>`
    --> log-0.3.8/src/lib.rs:604:34
@@ -96,7 +96,7 @@ warning: technically breaking changes in `<new::LogLocation as std::cmp::Partial
     |                                  ^^^^^^^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogLocation as std::cmp::Ord>`
    --> log-0.3.8/src/lib.rs:604:45
@@ -105,7 +105,7 @@ warning: technically breaking changes in `<new::LogLocation as std::cmp::Ord>`
     |                                             ^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogLocation as std::cmp::PartialOrd>`
    --> log-0.3.8/src/lib.rs:604:50
@@ -114,7 +114,7 @@ warning: technically breaking changes in `<new::LogLocation as std::cmp::Partial
     |                                                  ^^^^^^^^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogLocation as std::hash::Hash>`
    --> log-0.3.8/src/lib.rs:604:62
@@ -123,7 +123,7 @@ warning: technically breaking changes in `<new::LogLocation as std::hash::Hash>`
     |                                                              ^^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: path changes to `set_logger_raw`
    --> log-0.3.8/src/lib.rs:713:1

--- a/tests/full_cases/log-0.3.4-0.3.8.windows_msvc
+++ b/tests/full_cases/log-0.3.4-0.3.8.windows_msvc
@@ -6,7 +6,7 @@ warning: technically breaking changes in `<new::LogLevel as std::hash::Hash>`
     |                           ^^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogLevelFilter as std::hash::Hash>`
    --> log-0.3.8\src\lib.rs:410:27
@@ -15,7 +15,7 @@ warning: technically breaking changes in `<new::LogLevelFilter as std::hash::Has
     |                           ^^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogRecord<'a> as std::fmt::Debug>`
    --> log-0.3.8\src\lib.rs:517:10
@@ -24,7 +24,7 @@ warning: technically breaking changes in `<new::LogRecord<'a> as std::fmt::Debug
     |          ^^^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogMetadata<'a> as std::cmp::Eq>`
    --> log-0.3.8\src\lib.rs:552:10
@@ -33,7 +33,7 @@ warning: technically breaking changes in `<new::LogMetadata<'a> as std::cmp::Eq>
     |          ^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogMetadata<'a> as std::cmp::PartialEq>`
    --> log-0.3.8\src\lib.rs:552:14
@@ -42,7 +42,7 @@ warning: technically breaking changes in `<new::LogMetadata<'a> as std::cmp::Par
     |              ^^^^^^^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogMetadata<'a> as std::cmp::Ord>`
    --> log-0.3.8\src\lib.rs:552:25
@@ -51,7 +51,7 @@ warning: technically breaking changes in `<new::LogMetadata<'a> as std::cmp::Ord
     |                         ^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogMetadata<'a> as std::cmp::PartialOrd>`
    --> log-0.3.8\src\lib.rs:552:30
@@ -60,7 +60,7 @@ warning: technically breaking changes in `<new::LogMetadata<'a> as std::cmp::Par
     |                              ^^^^^^^^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogMetadata<'a> as std::hash::Hash>`
    --> log-0.3.8\src\lib.rs:552:42
@@ -69,7 +69,7 @@ warning: technically breaking changes in `<new::LogMetadata<'a> as std::hash::Ha
     |                                          ^^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogMetadata<'a> as std::fmt::Debug>`
    --> log-0.3.8\src\lib.rs:552:48
@@ -78,7 +78,7 @@ warning: technically breaking changes in `<new::LogMetadata<'a> as std::fmt::Deb
     |                                                ^^^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogLocation as std::cmp::Eq>`
    --> log-0.3.8\src\lib.rs:604:30
@@ -87,7 +87,7 @@ warning: technically breaking changes in `<new::LogLocation as std::cmp::Eq>`
     |                              ^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogLocation as std::cmp::PartialEq>`
    --> log-0.3.8\src\lib.rs:604:34
@@ -96,7 +96,7 @@ warning: technically breaking changes in `<new::LogLocation as std::cmp::Partial
     |                                  ^^^^^^^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogLocation as std::cmp::Ord>`
    --> log-0.3.8\src\lib.rs:604:45
@@ -105,7 +105,7 @@ warning: technically breaking changes in `<new::LogLocation as std::cmp::Ord>`
     |                                             ^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogLocation as std::cmp::PartialOrd>`
    --> log-0.3.8\src\lib.rs:604:50
@@ -114,7 +114,7 @@ warning: technically breaking changes in `<new::LogLocation as std::cmp::Partial
     |                                                  ^^^^^^^^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: technically breaking changes in `<new::LogLocation as std::hash::Hash>`
    --> log-0.3.8\src\lib.rs:604:62
@@ -123,7 +123,7 @@ warning: technically breaking changes in `<new::LogLocation as std::hash::Hash>`
     |                                                              ^^^^
     |
     = note: trait impl generalized or newly added (technically breaking)
-    = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this warning originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: path changes to `set_logger_raw`
    --> log-0.3.8\src\lib.rs:713:1

--- a/tests/full_cases/rmpv-0.4.0-0.4.1.linux
+++ b/tests/full_cases/rmpv-0.4.0-0.4.1.linux
@@ -46,27 +46,16 @@ error: breaking changes in `write_value_ref`
 warning: technically breaking changes in `as_ref`
    --> rmpv-0.4.1/src/lib.rs:253:5
     |
-253 | /     pub fn as_ref(&self) -> Utf8StringRef {
-254 | |         match self.s {
-255 | |             Ok(ref s) => Utf8StringRef { s: Ok(s.as_str()) },
-256 | |             Err((ref buf, err)) => Utf8StringRef { s: Err((&buf[..], err)) },
-257 | |         }
-258 | |     }
-    | |_____^
+253 |     pub fn as_ref(&self) -> Utf8StringRef {
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: added item in inherent impl (technically breaking)
 
 warning: technically breaking changes in `as_ref`
    --> rmpv-0.4.1/src/lib.rs:448:5
     |
-448 | /     pub fn as_ref(&self) -> ValueRef {
-449 | |         match self {
-450 | |             &Value::Nil => ValueRef::Nil,
-451 | |             &Value::Boolean(val) => ValueRef::Boolean(val),
-...   |
-464 | |         }
-465 | |     }
-    | |_____^
+448 |     pub fn as_ref(&self) -> ValueRef {
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: added item in inherent impl (technically breaking)
 

--- a/tests/full_cases/rmpv-0.4.0-0.4.1.osx
+++ b/tests/full_cases/rmpv-0.4.0-0.4.1.osx
@@ -46,27 +46,16 @@ error: breaking changes in `write_value_ref`
 warning: technically breaking changes in `as_ref`
    --> rmpv-0.4.1/src/lib.rs:253:5
     |
-253 | /     pub fn as_ref(&self) -> Utf8StringRef {
-254 | |         match self.s {
-255 | |             Ok(ref s) => Utf8StringRef { s: Ok(s.as_str()) },
-256 | |             Err((ref buf, err)) => Utf8StringRef { s: Err((&buf[..], err)) },
-257 | |         }
-258 | |     }
-    | |_____^
+253 |     pub fn as_ref(&self) -> Utf8StringRef {
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: added item in inherent impl (technically breaking)
 
 warning: technically breaking changes in `as_ref`
    --> rmpv-0.4.1/src/lib.rs:448:5
     |
-448 | /     pub fn as_ref(&self) -> ValueRef {
-449 | |         match self {
-450 | |             &Value::Nil => ValueRef::Nil,
-451 | |             &Value::Boolean(val) => ValueRef::Boolean(val),
-...   |
-464 | |         }
-465 | |     }
-    | |_____^
+448 |     pub fn as_ref(&self) -> ValueRef {
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: added item in inherent impl (technically breaking)
 

--- a/tests/full_cases/rmpv-0.4.0-0.4.1.windows_msvc
+++ b/tests/full_cases/rmpv-0.4.0-0.4.1.windows_msvc
@@ -46,27 +46,16 @@ error: breaking changes in `write_value_ref`
 warning: technically breaking changes in `as_ref`
    --> rmpv-0.4.1\src\lib.rs:253:5
     |
-253 | /     pub fn as_ref(&self) -> Utf8StringRef {
-254 | |         match self.s {
-255 | |             Ok(ref s) => Utf8StringRef { s: Ok(s.as_str()) },
-256 | |             Err((ref buf, err)) => Utf8StringRef { s: Err((&buf[..], err)) },
-257 | |         }
-258 | |     }
-    | |_____^
+253 |     pub fn as_ref(&self) -> Utf8StringRef {
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: added item in inherent impl (technically breaking)
 
 warning: technically breaking changes in `as_ref`
    --> rmpv-0.4.1\src\lib.rs:448:5
     |
-448 | /     pub fn as_ref(&self) -> ValueRef {
-449 | |         match self {
-450 | |             &Value::Nil => ValueRef::Nil,
-451 | |             &Value::Boolean(val) => ValueRef::Boolean(val),
-...   |
-464 | |         }
-465 | |     }
-    | |_____^
+448 |     pub fn as_ref(&self) -> ValueRef {
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: added item in inherent impl (technically breaking)
 


### PR DESCRIPTION
This needed mostly changes around `Predicate` and `Binder`.
Also re-blessed snapshots, some of which improved by pointing only to
the item signature instead of its whole body.

This is the first time I am touching rustc internals, so I am not 100% confident with that change, however all the tests pass, and some of the snapshots are even improving.