### PR TITLE
Rollup of 1 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,18 +931,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.126"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ env_logger = "0.9"
 anyhow = "1.0.42"
 log = "0.4"
 semver = "0.10" # Keep in sync with version pulled by Cargo
-serde = { version = "1.0.126", features = ["derive"] }
+serde = { version = "1.0.127", features = ["derive"] }
 serde_json = "1.0.64"
 
 [dev-dependencies]


### PR DESCRIPTION
Successful merges:

 - #209 (Bump serde from 1.0.126 to 1.0.127)

Failed merges:

 - #210 (Bump serde_json from 1.0.64 to 1.0.66)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/semverver?prs=209)
<!-- homu-ignore:end -->