### PR TITLE
More flexible rule around adding public fields to struct with private fields

### DIFF
--- a/src/changes.rs
+++ b/src/changes.rs
@@ -370,6 +370,9 @@ impl<'tcx> ChangeType<'tcx> {
     pub fn to_category(&self) -> ChangeCategory {
         // TODO: slightly messy and unreadable.
         match *self {
+            //
+            // Breaking
+            //
             ItemMadePrivate |
             KindDifference |
             StaticMutabilityChanged { now_mut: false } |
@@ -381,8 +384,7 @@ impl<'tcx> ChangeType<'tcx> {
             TypeParameterRemoved { .. } |
             VariantAdded |
             VariantRemoved |
-            VariantFieldAdded { public: true, .. } |
-            VariantFieldAdded { public: false, total_public: true, .. } |
+            VariantFieldAdded { total_public: true, .. } |
             VariantFieldRemoved { public: true, .. } |
             VariantFieldRemoved { public: false, is_enum: true, .. } |
             VariantStyleChanged { .. } |
@@ -397,12 +399,19 @@ impl<'tcx> ChangeType<'tcx> {
             TraitImplTightened |
             AssociatedItemRemoved |
             Unknown => Breaking,
+            //
+            // Technically breaking
+            //
             MethodSelfChanged { now_self: true } |
             TraitItemAdded { .. } | // either defaulted or sealed
             BoundsLoosened { trait_def: false, .. } |
             TraitImplLoosened |
             AssociatedItemAdded |
+            VariantFieldAdded { public: true, .. } |
             ItemMadePublic => TechnicallyBreaking,
+            //
+            // Non breaking
+            //
             StaticMutabilityChanged { now_mut: true } |
             VarianceLoosened |
             TypeParameterAdded { defaulted: true } |

--- a/tests/cases/structs/new.rs
+++ b/tests/cases/structs/new.rs
@@ -26,3 +26,8 @@ pub struct Ghi {
 pub struct Hij {
     field: u8,
 }
+
+pub struct Iij {
+    pub field1: u8,
+    pub field2: u8,
+}

--- a/tests/cases/structs/old.rs
+++ b/tests/cases/structs/old.rs
@@ -24,3 +24,7 @@ pub struct Ghi {
 }
 
 pub struct Hij(u8);
+
+pub struct Iij {
+    field: u16,
+}

--- a/tests/cases/structs/stdout
+++ b/tests/cases/structs/stdout
@@ -79,5 +79,29 @@ warning: tuple struct with no public fields changed to a regular struct (breakin
 28 | | }
    | |_^
 
-error: aborting due to 4 previous errors; 2 warnings emitted
+warning: technically breaking changes in `Iij`
+  --> structs/new.rs:30:1
+   |
+30 | / pub struct Iij {
+31 | |     pub field1: u8,
+32 | |     pub field2: u8,
+33 | | }
+   | |_^
+   |
+note: private field removed from struct with private fields (non-breaking)
+  --> structs/old.rs:29:5
+   |
+29 |     field: u16,
+   |     ^^^^^^^^^^
+note: public field added to struct with private fields (technically breaking)
+  --> structs/new.rs:31:5
+   |
+31 |     pub field1: u8,
+   |     ^^^^^^^^^^^^^^
+note: public field added to struct with private fields (technically breaking)
+  --> structs/new.rs:32:5
+   |
+32 |     pub field2: u8,
+   |     ^^^^^^^^^^^^^^
 
+error: aborting due to 4 previous errors; 3 warnings emitted


### PR DESCRIPTION
This comes from https://github.com/rust-lang/libc/pull/2451.

Before this PR, the `kinfo_proc` struct only had one field which was private. I added the missing fields and made them all public. It doesn't seem to be a semver breaking change as the code using this struct previously will still work exactly the same.