### PR TITLE
Do not rebase dependabot PRs automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
-       # These are peer deps of Cargo and should not be automatically bumped
-       - dependency-name: "semver"
-       - dependency-name: "crates-io"
+        # These are peer deps of Cargo and should not be automatically bumped
+        - dependency-name: "semver"
+        - dependency-name: "crates-io"
+    rebase-strategy: "disabled"


### PR DESCRIPTION
Rebasing needs re-approvals for dependabot PRs when we use bors, it's annoying. This disables that behavior and we can explicitly do it via the command, `@bot rebase` if needed.