### PR TITLE
Pin proc_macro2 dependency to v1.0.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,6 +931,7 @@ dependencies = [
  "curl",
  "env_logger",
  "log",
+ "proc-macro2",
  "quickcheck",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ log = "0.4"
 semver = "1.0" # Keep in sync with version pulled by Cargo
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.72"
+proc-macro2 = "=1.0.32"
 
 [dev-dependencies]
 quickcheck = { version = "1.0", default-features = false }


### PR DESCRIPTION
Fixes #246 by pinning proc_macro2 to the last version compatible with recommended nightly-2021-09-30.