### PR TITLE
fix: pin quote to 1.0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ log = "0.4"
 semver = "1.0" # Keep in sync with version pulled by Cargo
 serde = { version = "1.0.133", features = ["derive"] }
 serde_json = "1.0.74"
+quote = "=1.0.10"
 proc-macro2 = "=1.0.32"
 
 [dev-dependencies]


### PR DESCRIPTION
This pins the version of quote to `1.0.10`, which fixes the installation issue in https://github.com/rust-lang/rust-semverver/issues/257