### PR TITLE
Update nightly toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ repository and compiled from source or installed from
 of the nightly toolchain is supported at any given time.
 
 <!-- NOTE: Keep in sync with nightly date on rust-toolchain. -->
-It's recommended to use `nightly-2021-09-30` toolchain.
-You can install it by using `rustup install nightly-2021-09-30` if you already have rustup.
+It's recommended to use `nightly-2021-10-15` toolchain.
+You can install it by using `rustup install nightly-2021-10-15` if you already have rustup.
 Then you can do:
 
 ```sh
-$ rustup component add rustc-dev llvm-tools-preview --toolchain nightly-2021-09-30
-$ cargo +nightly-2021-09-30 install --git https://github.com/rust-lang/rust-semverver
+$ rustup component add rustc-dev llvm-tools-preview --toolchain nightly-2021-10-15
+$ cargo +nightly-2021-10-15 install --git https://github.com/rust-lang/rust-semverver
 ```
 
 You'd also need `cmake` for some dependencies, and a few common libraries (if you hit

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ repository and compiled from source or installed from
 of the nightly toolchain is supported at any given time.
 
 <!-- NOTE: Keep in sync with nightly date on rust-toolchain. -->
-It's recommended to use `nightly-2021-10-15` toolchain.
-You can install it by using `rustup install nightly-2021-10-15` if you already have rustup.
+It's recommended to use `nightly-2021-10-16` toolchain.
+You can install it by using `rustup install nightly-2021-10-16` if you already have rustup.
 Then you can do:
 
 ```sh
-$ rustup component add rustc-dev llvm-tools-preview --toolchain nightly-2021-10-15
-$ cargo +nightly-2021-10-15 install --git https://github.com/rust-lang/rust-semverver
+$ rustup component add rustc-dev llvm-tools-preview --toolchain nightly-2021-10-16
+$ cargo +nightly-2021-10-16 install --git https://github.com/rust-lang/rust-semverver
 ```
 
 You'd also need `cmake` for some dependencies, and a few common libraries (if you hit

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ repository and compiled from source or installed from
 of the nightly toolchain is supported at any given time.
 
 <!-- NOTE: Keep in sync with nightly date on rust-toolchain. -->
-It's recommended to use `nightly-2021-10-16` toolchain.
-You can install it by using `rustup install nightly-2021-10-16` if you already have rustup.
+It's recommended to use `nightly-2021-10-20` toolchain.
+You can install it by using `rustup install nightly-2021-10-20` if you already have rustup.
 Then you can do:
 
 ```sh
-$ rustup component add rustc-dev llvm-tools-preview --toolchain nightly-2021-10-16
-$ cargo +nightly-2021-10-16 install --git https://github.com/rust-lang/rust-semverver
+$ rustup component add rustc-dev llvm-tools-preview --toolchain nightly-2021-10-20
+$ cargo +nightly-2021-10-20 install --git https://github.com/rust-lang/rust-semverver
 ```
 
 You'd also need `cmake` for some dependencies, and a few common libraries (if you hit

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ repository and compiled from source or installed from
 of the nightly toolchain is supported at any given time.
 
 <!-- NOTE: Keep in sync with nightly date on rust-toolchain. -->
-It's recommended to use `nightly-2021-10-20` toolchain.
-You can install it by using `rustup install nightly-2021-10-20` if you already have rustup.
+It's recommended to use `nightly-2021-10-25` toolchain.
+You can install it by using `rustup install nightly-2021-10-25` if you already have rustup.
 Then you can do:
 
 ```sh
-$ rustup component add rustc-dev llvm-tools-preview --toolchain nightly-2021-10-20
-$ cargo +nightly-2021-10-20 install --git https://github.com/rust-lang/rust-semverver
+$ rustup component add rustc-dev llvm-tools-preview --toolchain nightly-2021-10-25
+$ cargo +nightly-2021-10-25 install --git https://github.com/rust-lang/rust-semverver
 ```
 
 You'd also need `cmake` for some dependencies, and a few common libraries (if you hit

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 # NOTE: Keep in sync with nightly date on README
 [toolchain]
-channel = "nightly-2021-09-30"
+channel = "nightly-2021-10-15"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 # NOTE: Keep in sync with nightly date on README
 [toolchain]
-channel = "nightly-2021-10-16"
+channel = "nightly-2021-10-20"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 # NOTE: Keep in sync with nightly date on README
 [toolchain]
-channel = "nightly-2021-10-15"
+channel = "nightly-2021-10-16"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 # NOTE: Keep in sync with nightly date on README
 [toolchain]
-channel = "nightly-2021-10-20"
+channel = "nightly-2021-10-25"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -393,6 +393,7 @@ impl<'a, 'tcx> TranslationContext<'a, 'tcx> {
                             substs: target_substs,
                         },
                         constness: pred.constness,
+                        polarity: pred.polarity,
                     }
                 } else {
                     return None;

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -17,7 +17,6 @@ use crate::{
     typeck::{BoundContext, TypeComparisonContext},
 };
 use log::{debug, info};
-use rustc_const_eval::const_eval::is_const_fn;
 use rustc_hir::def::{CtorKind, CtorOf, DefKind, Res, Res::Def};
 use rustc_hir::def_id::DefId;
 use rustc_hir::hir_id::HirId;
@@ -363,8 +362,8 @@ fn diff_fn<'tcx>(changes: &mut ChangeSet, tcx: TyCtxt<'tcx>, old: Res, new: Res)
     let old_def_id = old.def_id();
     let new_def_id = new.def_id();
 
-    let old_const = is_const_fn(tcx, old_def_id);
-    let new_const = is_const_fn(tcx, new_def_id);
+    let old_const = tcx.is_const_fn(old_def_id);
+    let new_const = tcx.is_const_fn(new_def_id);
 
     if old_const != new_const {
         changes.add_change(

--- a/src/typeck.rs
+++ b/src/typeck.rs
@@ -18,7 +18,8 @@ use rustc_middle::{
         error::TypeError,
         fold::TypeFoldable,
         subst::{GenericArg, InternalSubsts, SubstsRef},
-        GenericParamDefKind, ParamEnv, Predicate, PredicateKind, TraitRef, Ty, TyCtxt,
+        GenericParamDefKind, ImplPolarity, ParamEnv, Predicate, PredicateKind, TraitRef, Ty,
+        TyCtxt,
     },
 };
 use rustc_trait_selection::traits::FulfillmentContext;
@@ -77,6 +78,7 @@ impl<'a, 'tcx> BoundContext<'a, 'tcx> {
         let predicate = ty::Binder::dummy(PredicateKind::Trait(TraitPredicate {
             trait_ref: checked_trait_ref,
             constness: BoundConstness::NotConst,
+            polarity: ImplPolarity::Positive,
         }))
         .to_predicate(self.infcx.tcx);
         let obligation = Obligation::new(ObligationCause::dummy(), self.given_param_env, predicate);

--- a/tests/cases/pathologic_paths/stdout
+++ b/tests/cases/pathologic_paths/stdout
@@ -9,7 +9,7 @@ warning: path changes to `a`
 ...  |
 16 | |       _ _ _ _ _ _ _ _
 17 | |       _ _ _ _ _ _ _ _);
-   | |_______________________^
+   | |______________________^
    |
    = note: added definition (technically breaking)
    = note: this warning originates in the macro `blow` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -24,7 +24,7 @@ warning: path changes to `b`
 ...  |
 16 | |       _ _ _ _ _ _ _ _
 17 | |       _ _ _ _ _ _ _ _);
-   | |_______________________^
+   | |______________________^
    |
    = note: added definition (technically breaking)
    = note: this warning originates in the macro `blow` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Attempting to update the nightly toolchain version. I don't know what I'm getting into, but I'll try my best 😅

I understand there were CI issues with nightly-2021-10-15 in #227, but the logs are gone from that time. I will push each nightly upgrade as its own commit in this PR so we can see CI for each.