### PR TITLE
Update rustc to nightly-2022-04-20

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ repository and compiled from source or installed from
 of the nightly toolchain is supported at any given time.
 
 <!-- NOTE: Keep in sync with nightly date on rust-toolchain. -->
-It's recommended to use `nightly-2022-03-13` toolchain.
-You can install it by using `rustup install nightly-2022-03-13` if you already have rustup.
+It's recommended to use `nightly-2022-04-20` toolchain.
+You can install it by using `rustup install nightly-2022-04-20` if you already have rustup.
 Then you can do:
 
 ```sh
-$ rustup component add rustc-dev llvm-tools-preview --toolchain nightly-2022-03-13
-$ cargo +nightly-2022-03-13 install --git https://github.com/rust-lang/rust-semverver
+$ rustup component add rustc-dev llvm-tools-preview --toolchain nightly-2022-04-20
+$ cargo +nightly-2022-04-20 install --git https://github.com/rust-lang/rust-semverver
 ```
 
 You'd also need `cmake` for some dependencies, and a few common libraries (if you hit

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 # NOTE: Keep in sync with nightly date on README
 [toolchain]
-channel = "nightly-2022-04-02"
+channel = "nightly-2022-04-20"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 # NOTE: Keep in sync with nightly date on README
 [toolchain]
-channel = "nightly-2022-03-13"
+channel = "nightly-2022-04-02"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -344,7 +344,7 @@ impl NameMapping {
                 Fn |
                 Const |
                 ConstParam |
-                Static |
+                Static(_) |
                 Ctor(_, _) |
                 AssocFn |
                 AssocConst => Some(&mut self.value_map),

--- a/src/mismatch.rs
+++ b/src/mismatch.rs
@@ -255,7 +255,7 @@ impl<'a, 'tcx> TypeRelation<'tcx> for MismatchRelation<'a, 'tcx> {
             }
             (&TyKind::Opaque(_a_def_id, a_substs), &TyKind::Opaque(_b_def_id, b_substs)) => {
                 if self.check_substs(a_substs, b_substs) {
-                    let _ = ty::relate::relate_substs(self, None, a_substs, b_substs)?;
+                    let _ = ty::relate::relate_substs(self, a_substs, b_substs)?;
                 }
 
                 // TODO: we are talking impl trait here, so we can build a Res for that or the


### PR DESCRIPTION
Seems i missed those in the last big upgrade PR. This should make the nightly CI job using `rustc`'s nightly `master` build green again.