### PR TITLE
Update style check CI job descriptions

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -12,13 +12,13 @@ jobs:
     strategy:
       fail-fast: false
 
-    name: Shellcheck
+    name: Style and Linters
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Run tests
+      - name: Shellcheck
         run: |
           shellcheck --version
           shellcheck ci/*.sh


### PR DESCRIPTION
The overall label "Shellcheck" somewhat hid the `clippy` and `rustfmt` runs underneath, so change it to "Style and Linters"