### PR TITLE
Upgrade Cargo to 0.62.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,9 +86,9 @@ checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
 
 [[package]]
 name = "cargo"
-version = "0.61.1"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f76f22dfcbc8e5aaa4e150373354723efe22b6b2280805f1fb6b1363005e7bab"
+checksum = "79bc435c2de37f164b5c36420d9e1dd65cd5acbd41b2df10fdc02dbf75ed9efc"
 dependencies = [
  "anyhow",
  "atty",
@@ -120,7 +120,6 @@ dependencies = [
  "libgit2-sys",
  "log",
  "memchr",
- "num_cpus",
  "opener",
  "os_info",
  "percent-encoding",
@@ -718,16 +717,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 exclude = ["/ci/*", "/.github/*", "/doc"]
 
 [dependencies]
-cargo = "0.61"
+cargo = "0.62"
 crates-io = "0.34" # Keep in sync with version pulled by Cargo
 curl = "0.4.43"
 env_logger = "0.9"

--- a/src/bin/cargo-semver.rs
+++ b/src/bin/cargo-semver.rs
@@ -456,13 +456,13 @@ impl<'a> WorkInfo<'a> {
     ) -> Result<WorkInfo<'a>> {
         let source = {
             let source_id = SourceId::crates_io(config)?;
-            let mut source = RegistrySource::remote(source_id, &HashSet::new(), config);
+            let mut source = RegistrySource::remote(source_id, &HashSet::new(), config)?;
 
             debug!("source id loaded: {:?}", source_id);
 
             if !config.offline() {
                 let _lock = config.acquire_package_cache_lock()?;
-                source.update()?;
+                source.invalidate_cache();
             }
 
             Box::new(source)


### PR DESCRIPTION
Address the changes on https://github.com/rust-lang/cargo/pull/10064